### PR TITLE
Update MySQL's auto-inc tokenization

### DIFF
--- a/src/Definitions/ColumnDefinition.php
+++ b/src/Definitions/ColumnDefinition.php
@@ -25,6 +25,8 @@ class ColumnDefinition
 
     protected ?string $collation = null;
 
+    protected bool $autoIncrementing = false;
+
     protected bool $index = false;
 
     protected bool $primary = false;
@@ -104,6 +106,14 @@ class ColumnDefinition
     public function getCollation(): ?string
     {
         return $this->collation;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAutoIncrementing(): bool
+    {
+        return $this->autoIncrementing;
     }
 
     /**
@@ -228,6 +238,17 @@ class ColumnDefinition
     }
 
     /**
+     * @param bool $autoIncrementing
+     * @return ColumnDefinition
+     */
+    public function setAutoIncrementing(bool $autoIncrementing): ColumnDefinition
+    {
+        $this->autoIncrementing = $autoIncrementing;
+
+        return $this;
+    }
+
+    /**
      * @param bool $index
      * @return ColumnDefinition
      */
@@ -301,7 +322,7 @@ class ColumnDefinition
 
     protected function guessLaravelMethod()
     {
-        if ($this->primary && $this->unsigned) {
+        if ($this->primary && $this->unsigned && $this->autoIncrementing) {
             //some sort of increments field
             if ($this->methodName === 'bigInteger') {
                 if ($this->columnName === 'id') {

--- a/src/Tokenizers/MySQL/ColumnTokenizer.php
+++ b/src/Tokenizers/MySQL/ColumnTokenizer.php
@@ -35,6 +35,7 @@ class ColumnTokenizer extends BaseColumnTokenizer
         $this->consumeDefaultValue();
         if ($this->isNumberType()) {
             $this->consumeAutoIncrement();
+            $this->consumeKeyConstraints();
         }
 
         return $this;
@@ -81,7 +82,7 @@ class ColumnTokenizer extends BaseColumnTokenizer
     {
         $piece = $this->consume();
         if (strtoupper($piece) === 'AUTO_INCREMENT') {
-            $this->definition->setPrimary(true);
+            $this->definition->setAutoIncrementing(true);
         } else {
             $this->putBack($piece);
         }
@@ -151,6 +152,28 @@ class ColumnTokenizer extends BaseColumnTokenizer
             $this->definition->setUnsigned(true);
         } else {
             $this->putBack($piece);
+        }
+    }
+
+    private function consumeKeyConstraints()
+    {
+        $nextPiece = $this->consume();
+        if (strtoupper($nextPiece) === 'PRIMARY') {
+            $this->definition->setPrimary(true);
+
+            $next = $this->consume();
+            if (strtoupper($next) !== 'KEY') {
+                $this->putBack($next);
+            }
+        } elseif (strtoupper($nextPiece) === 'UNIQUE') {
+            $this->definition->setUnique(true);
+
+            $next = $this->consume();
+            if (strtoupper($next) !== 'KEY') {
+                $this->putBack($next);
+            }
+        } else {
+            $this->putBack($nextPiece);
         }
     }
 

--- a/tests/Unit/Generators/MySQLTableGeneratorTest.php
+++ b/tests/Unit/Generators/MySQLTableGeneratorTest.php
@@ -121,4 +121,37 @@ class MySQLTableGeneratorTest extends TestCase
         $schema = $generator->getSchema();
         $this->assertSchemaHas('$table->uuidMorphs(\'user\')->nullable();', $schema);
     }
+
+    public function test_doesnt_clean_non_auto_inc_id_to_laravel_method()
+    {
+        $generator = TableGenerator::init('table', [
+            '`id` int(9) unsigned NOT NULL',
+            'PRIMARY KEY `id`'
+        ]);
+
+        $schema = $generator->getSchema();
+        $this->assertSchemaHas('$table->integer(\'id\')->unsigned()->primary();', $schema);
+    }
+
+    public function test_does_clean_auto_inc_int_to_laravel_method()
+    {
+        $generator = TableGenerator::init('table', [
+            '`id` int(9) unsigned NOT NULL AUTO_INCREMENT',
+            'PRIMARY KEY `id`'
+        ]);
+
+        $schema = $generator->getSchema();
+        $this->assertSchemaHas('$table->increments(\'id\');', $schema);
+    }
+
+    public function test_does_clean_auto_inc_big_int_to_laravel_method()
+    {
+        $generator = TableGenerator::init('table', [
+            '`id` bigint(12) unsigned NOT NULL AUTO_INCREMENT',
+            'PRIMARY KEY `id`'
+        ]);
+
+        $schema = $generator->getSchema();
+        $this->assertSchemaHas('$table->id();', $schema);
+    }
 }

--- a/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
+++ b/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
@@ -252,10 +252,11 @@ class ColumnTokenizerTest extends TestCase
         $this->assertEquals('int', $columnTokenizer->getColumnDataType());
         $this->assertEquals('integer', $columnDefinition->getMethodName());
         $this->assertCount(0, $columnDefinition->getMethodParameters());
+        $this->assertFalse($columnDefinition->isPrimary());
         $this->assertFalse($columnDefinition->isNullable());
         $this->assertTrue($columnDefinition->isUnsigned());
         $this->assertNull($columnDefinition->getCollation());
-        $this->assertEquals('$table->increments(\'id\')', $columnDefinition->render());
+        $this->assertEquals('$table->integer(\'id\')->unsigned()', $columnDefinition->render());
     }
 
     //endregion


### PR DESCRIPTION
The tokenizer should only guess the `increments` or `id` when the field is auto-inc.
Resolves Issue #3 