### PR TITLE
Add config option to add `unsigned` prefix to column definitions

### DIFF
--- a/config/laravel-migration-generator.php
+++ b/config/laravel-migration-generator.php
@@ -8,6 +8,9 @@ return [
     'skippable_tables'    => [
         'migrations'
     ],
+    'definitions' => [
+        'prefer_unsigned_prefix' => true
+    ],
 
     //now driver specific configs
     //null = use default

--- a/src/Definitions/ColumnDefinition.php
+++ b/src/Definitions/ColumnDefinition.php
@@ -366,6 +366,20 @@ class ColumnDefinition
             return [$this->columnName, 'uuid', []];
         }
 
+        if (config('laravel-migration-generator.definitions.prefer_unsigned_prefix') && $this->unsigned) {
+            $availableUnsignedPrefixes = [
+                'bigInteger',
+                'decimal',
+                'integer',
+                'mediumInteger',
+                'smallInteger',
+                'tinyInteger'
+            ];
+            if (in_array($this->methodName, $availableUnsignedPrefixes)) {
+                return [$this->columnName, 'unsigned' . ucfirst($this->methodName), $this->methodParameters];
+            }
+        }
+
         return [$this->columnName, $this->methodName, $this->methodParameters];
     }
 
@@ -383,7 +397,7 @@ class ColumnDefinition
             }
         }
         $initialString .= ')';
-        if ($this->unsigned && $this->canBeUnsigned($finalMethodName)) {
+        if ($this->unsigned && $this->canBeUnsigned($finalMethodName) && ! Str::startsWith($finalMethodName, 'unsigned')) {
             $initialString .= '->unsigned()';
         }
         if ($this->nullable && $this->isNullableMethod($finalMethodName)) {

--- a/tests/Unit/Generators/MySQLTableGeneratorTest.php
+++ b/tests/Unit/Generators/MySQLTableGeneratorTest.php
@@ -33,7 +33,7 @@ class MySQLTableGeneratorTest extends TestCase
 
         $schema = $generator->getSchema();
         $this->assertSchemaHas('$table->increments(\'id\');', $schema);
-        $this->assertSchemaHas('$table->integer(\'user_id\')->unsigned();', $schema);
+        $this->assertSchemaHas('$table->unsignedInteger(\'user_id\');', $schema);
         $this->assertSchemaHas('$table->string(\'note\');', $schema);
         $this->assertSchemaHas('$table->foreign(\'user_id\', \'fk_user_id\')->references(\'id\')->on(\'users\')->onDelete(\'cascade\')->onUpdate(\'cascade\');', $schema);
     }
@@ -130,7 +130,7 @@ class MySQLTableGeneratorTest extends TestCase
         ]);
 
         $schema = $generator->getSchema();
-        $this->assertSchemaHas('$table->integer(\'id\')->unsigned()->primary();', $schema);
+        $this->assertSchemaHas('$table->unsignedInteger(\'id\')->primary();', $schema);
     }
 
     public function test_does_clean_auto_inc_int_to_laravel_method()

--- a/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
+++ b/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
@@ -224,7 +224,7 @@ class ColumnTokenizerTest extends TestCase
         $this->assertFalse($columnDefinition->isNullable());
         $this->assertTrue($columnDefinition->isUnsigned());
         $this->assertNull($columnDefinition->getCollation());
-        $this->assertEquals('$table->smallInteger(\'cats\')->unsigned()', $columnDefinition->render());
+        $this->assertEquals('$table->unsignedSmallInteger(\'cats\')', $columnDefinition->render());
     }
 
     public function test_it_tokenizes_a_nullable_big_int_column()
@@ -240,7 +240,7 @@ class ColumnTokenizerTest extends TestCase
         $this->assertTrue($columnDefinition->isUnsigned());
         $this->assertNull($columnDefinition->getCollation());
         $this->assertNull($columnDefinition->getDefaultValue());
-        $this->assertEquals('$table->bigInteger(\'template_id\')->unsigned()->nullable()', $columnDefinition->render());
+        $this->assertEquals('$table->unsignedBigInteger(\'template_id\')->nullable()', $columnDefinition->render());
     }
 
     public function test_it_tokenizes_a_primary_auto_inc_int_column()
@@ -256,7 +256,16 @@ class ColumnTokenizerTest extends TestCase
         $this->assertFalse($columnDefinition->isNullable());
         $this->assertTrue($columnDefinition->isUnsigned());
         $this->assertNull($columnDefinition->getCollation());
-        $this->assertEquals('$table->integer(\'id\')->unsigned()', $columnDefinition->render());
+        $this->assertEquals('$table->unsignedInteger(\'id\')', $columnDefinition->render());
+    }
+
+    public function test_definition_config()
+    {
+        config()->set('laravel-migration-generator.definitions.prefer_unsigned_prefix', false);
+        $columnTokenizer = ColumnTokenizer::parse('`column` int(9) unsigned NOT NULL');
+        $columnDefinition = $columnTokenizer->definition();
+        $this->assertEquals('$table->integer(\'column\')->unsigned()', $columnDefinition->render());
+        config()->set('laravel-migration-generator.definitions.prefer_unsigned_prefix', true);
     }
 
     //endregion
@@ -411,7 +420,7 @@ class ColumnTokenizerTest extends TestCase
         $this->assertFalse($columnDefinition->isNullable());
         $this->assertTrue($columnDefinition->isUnsigned());
         $this->assertNull($columnDefinition->getCollation());
-        $this->assertEquals('$table->decimal(\'amount\', 9, 2)->unsigned()', $columnDefinition->render());
+        $this->assertEquals('$table->unsignedDecimal(\'amount\', 9, 2)', $columnDefinition->render());
     }
 
     public function test_it_tokenizes_a_not_null_decimal_with_default_value_column()
@@ -446,7 +455,7 @@ class ColumnTokenizerTest extends TestCase
         $this->assertFalse($columnDefinition->isNullable());
         $this->assertTrue($columnDefinition->isUnsigned());
         $this->assertNull($columnDefinition->getCollation());
-        $this->assertEquals('$table->decimal(\'amount\', 9, 2)->unsigned()->default(1.00)', $columnDefinition->render());
+        $this->assertEquals('$table->unsignedDecimal(\'amount\', 9, 2)->default(1.00)', $columnDefinition->render());
     }
 
     //endregion


### PR DESCRIPTION
For: bigInteger, decimal, integer, mediumInteger, smallInteger, and tinyInteger