### PR TITLE
Update single column index methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Want to customize the migration stubs? Make sure you've published the vendor ass
 | Key | Values | Description |
 | --- | ------ | ----------- |
 | prefer_unsigned_prefix | boolean | Set to true to use the `unsigned` prefix for the applicable fields (integer, smallInteger, etc). Set to false to use the `unsigned()` modifier. |
-
+| use_defined_index_names | boolean | Set to true to use the defined index names as second parameter for the `->index()` method. Set to false to default to Laravel's index naming scheme. |
+| use_defined_foreign_key_index_names | boolean | Set to true to use the defined index names for foreign keys as second parameter for the `->foreign()` method. Set to false to default to Laravel's index naming scheme. |
+| use_defined_unique_key_index_names | boolean | Set to true to use the defined index names for unique keys as second parameter for the `->unique()` method. Set to false to default to Laravel's index naming scheme. |
+| use_defined_primary_key_index_names | boolean | Set to true to use the defined index names for primary keys as second parameter for the `->primary()` method. Set to false to default to Laravel's index naming scheme. |
 
 ## Stubs
 There is a default stub for tables and views, found in `resources/stubs/vendor/laravel-migration-generator/`.

--- a/config/laravel-migration-generator.php
+++ b/config/laravel-migration-generator.php
@@ -9,7 +9,11 @@ return [
         'migrations'
     ],
     'definitions' => [
-        'prefer_unsigned_prefix' => true
+        'prefer_unsigned_prefix'              => true,
+        'use_defined_index_names'             => true,
+        'use_defined_foreign_key_index_names' => true,
+        'use_defined_unique_key_index_names'  => true,
+        'use_defined_primary_key_index_names' => true
     ],
 
     //now driver specific configs

--- a/src/Definitions/ColumnDefinition.php
+++ b/src/Definitions/ColumnDefinition.php
@@ -37,6 +37,9 @@ class ColumnDefinition
 
     protected bool $isUUID = false;
 
+    /** @var IndexDefinition[] */
+    protected array $indexDefinitions = [];
+
     public function __construct($attributes = [])
     {
         foreach ($attributes as $attribute => $value) {
@@ -248,6 +251,13 @@ class ColumnDefinition
         return $this;
     }
 
+    public function addIndexDefinition(IndexDefinition $definition): ColumnDefinition
+    {
+        $this->indexDefinitions[] = $definition;
+
+        return $this;
+    }
+
     /**
      * @param bool $index
      * @return ColumnDefinition
@@ -417,15 +427,29 @@ class ColumnDefinition
         }
 
         if ($this->index) {
-            $initialString .= '->index()';
+            $indexName = '';
+            if (count($this->indexDefinitions) === 1 && config('laravel-migration-generator.definitions.use_defined_index_names')) {
+                $indexName = ValueToString::make($this->indexDefinitions[0]->getIndexName());
+            }
+            $initialString .= '->index(' . $indexName . ')';
         }
 
         if ($this->primary && ! $this->isPrimaryKeyMethod($finalMethodName)) {
-            $initialString .= '->primary()';
+            $indexName = '';
+            if (count($this->indexDefinitions) === 1 && config('laravel-migration-generator.definitions.use_defined_primary_key_index_names')) {
+                if($this->indexDefinitions[0]->getIndexName() !== null) {
+                    $indexName = ValueToString::make($this->indexDefinitions[0]->getIndexName());
+                }
+            }
+            $initialString .= '->primary(' . $indexName . ')';
         }
 
         if ($this->unique) {
-            $initialString .= '->unique()';
+            $indexName = '';
+            if (count($this->indexDefinitions) === 1 && config('laravel-migration-generator.definitions.use_defined_unique_key_index_names')) {
+                $indexName = ValueToString::make($this->indexDefinitions[0]->getIndexName());
+            }
+            $initialString .= '->unique(' . $indexName . ')';
         }
 
         return $initialString;

--- a/src/Definitions/IndexDefinition.php
+++ b/src/Definitions/IndexDefinition.php
@@ -156,18 +156,36 @@ class IndexDefinition
     public function render(): string
     {
         if ($this->indexType === 'foreign') {
-            $base = '$table->foreign(' . ValueToString::make($this->indexColumns, true) . ', ' . ValueToString::make($this->indexName) . ')->references(' . ValueToString::make($this->foreignReferencedColumns, true) . ')->on(' . ValueToString::make($this->foreignReferencedTable) . ')';
+            $indexName = '';
+            if (config('laravel-migration-generator.definitions.use_defined_foreign_key_index_names')) {
+                $indexName = ', \'' . $this->getIndexName() . '\'';
+            }
+
+            $base = '$table->foreign(' . ValueToString::make($this->indexColumns, true) . $indexName . ')->references(' . ValueToString::make($this->foreignReferencedColumns, true) . ')->on(' . ValueToString::make($this->foreignReferencedTable) . ')';
             foreach ($this->constraintActions as $type => $action) {
                 $base .= '->on' . ucfirst($type) . '(' . ValueToString::make($action) . ')';
             }
 
             return $base;
         } elseif ($this->indexType === 'primary') {
-            return '$table->primary(' . ValueToString::make($this->indexColumns) . ')';
+            $indexName = '';
+            if (config('laravel-migration-generator.definitions.use_defined_primary_key_index_names') && $this->getIndexName() !== null) {
+                $indexName = ', \'' . $this->getIndexName() . '\'';
+            }
+
+            return '$table->primary(' . ValueToString::make($this->indexColumns) . $indexName . ')';
         } elseif ($this->indexType === 'unique') {
-            return '$table->unique(' . ValueToString::make($this->indexColumns) . ', ' . ValueToString::make($this->indexName) . ')';
+            $indexName = '';
+            if (config('laravel-migration-generator.definitions.use_defined_unique_key_index_names')) {
+                $indexName = ', \'' . $this->getIndexName() . '\'';
+            }
+            return '$table->unique(' . ValueToString::make($this->indexColumns) . $indexName . ')';
         } elseif ($this->indexType === 'index') {
-            return '$table->index(' . ValueToString::make($this->indexColumns) . ', ' . ValueToString::make($this->indexName) . ')';
+            $indexName = '';
+            if (config('laravel-migration-generator.definitions.use_defined_index_names')) {
+                $indexName = ', \'' . $this->getIndexName() . '\'';
+            }
+            return '$table->index(' . ValueToString::make($this->indexColumns) . $indexName . ')';
         }
 
         return '';

--- a/src/Generators/Concerns/CleansUpColumnIndices.php
+++ b/src/Generators/Concerns/CleansUpColumnIndices.php
@@ -26,13 +26,13 @@ trait CleansUpColumnIndices
                         $isMultiColumnIndex = $index->definition()->isMultiColumnIndex();
 
                         if ($indexType === 'primary' && ! $isMultiColumnIndex) {
-                            $column->definition()->setPrimary(true);
+                            $column->definition()->setPrimary(true)->addIndexDefinition($index->definition());
                             $index->markAsWritable(false);
                         } elseif ($indexType === 'index' && ! $isMultiColumnIndex) {
-                            $column->definition()->setIndex(true);
+                            $column->definition()->setIndex(true)->addIndexDefinition($index->definition());
                             $index->markAsWritable(false);
                         } elseif ($indexType === 'unique' && ! $isMultiColumnIndex) {
-                            $column->definition()->setUnique(true);
+                            $column->definition()->setUnique(true)->addIndexDefinition($index->definition());
                             $index->markAsWritable(false);
                         }
                     }

--- a/tests/Unit/ColumnDefinitionTest.php
+++ b/tests/Unit/ColumnDefinitionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use LaravelMigrationGenerator\Definitions\IndexDefinition;
+use LaravelMigrationGenerator\Definitions\ColumnDefinition;
+
+class ColumnDefinitionTest extends TestCase
+{
+    public function test_it_can_add_index_definitions()
+    {
+        $columnDefinition = (new ColumnDefinition())->setIndex(true)->setColumnName('testing')->setMethodName('string');
+        $indexDefinition = (new IndexDefinition())->setIndexName('test')->setIndexType('index');
+        $columnDefinition->addIndexDefinition($indexDefinition);
+
+        $this->assertEquals('$table->string(\'testing\')->nullable()->index(\'test\')', $columnDefinition->render());
+    }
+
+    public function test_it_prunes_empty_primary_key_index()
+    {
+        $columnDefinition = (new ColumnDefinition())
+            ->setPrimary(true)
+            ->setColumnName('testing')
+            ->setNullable(false)
+            ->setUnsigned(true)
+            ->setMethodName('integer');
+        $indexDefinition = (new IndexDefinition())
+            ->setIndexType('primary');
+        $columnDefinition->addIndexDefinition($indexDefinition);
+
+        $this->assertEquals('$table->unsignedInteger(\'testing\')->primary()', $columnDefinition->render());
+    }
+}

--- a/tests/Unit/Tokenizers/MySQL/IndexTokenizerTest.php
+++ b/tests/Unit/Tokenizers/MySQL/IndexTokenizerTest.php
@@ -19,6 +19,19 @@ class IndexTokenizerTest extends TestCase
         $this->assertEquals('$table->index([\'email\'], \'password_resets_email_index\')', $indexDefinition->render());
     }
 
+    public function test_it_doesnt_use_index_name()
+    {
+        config()->set('laravel-migration-generator.definitions.use_defined_index_names', false);
+        $indexTokenizer = IndexTokenizer::parse('KEY `password_resets_email_index` (`email`)');
+        $indexDefinition = $indexTokenizer->definition();
+
+        $this->assertEquals('index', $indexDefinition->getIndexType());
+        $this->assertFalse($indexDefinition->isMultiColumnIndex());
+
+        $this->assertEquals('$table->index([\'email\'])', $indexDefinition->render());
+        config()->set('laravel-migration-generator.definitions.use_defined_index_names', true);
+    }
+
     //endregion
 
     //region Primary Key
@@ -60,6 +73,19 @@ class IndexTokenizerTest extends TestCase
         $this->assertEquals('$table->unique([\'email\'], \'users_email_unique\')', $indexDefinition->render());
     }
 
+    public function test_it_doesnt_use_unique_key_index_name()
+    {
+        config()->set('laravel-migration-generator.definitions.use_defined_unique_key_index_names', false);
+        $indexTokenizer = IndexTokenizer::parse('UNIQUE KEY `users_email_unique` (`email`)');
+        $indexDefinition = $indexTokenizer->definition();
+
+        $this->assertEquals('unique', $indexDefinition->getIndexType());
+        $this->assertFalse($indexDefinition->isMultiColumnIndex());
+
+        $this->assertEquals('$table->unique([\'email\'])', $indexDefinition->render());
+        config()->set('laravel-migration-generator.definitions.use_defined_unique_key_index_names', true);
+    }
+
     public function test_it_tokenizes_two_column_unique_key()
     {
         $indexTokenizer = IndexTokenizer::parse('UNIQUE KEY `users_email_location_id_unique` (`email`,`location_id`)');
@@ -71,6 +97,21 @@ class IndexTokenizerTest extends TestCase
         $this->assertEqualsCanonicalizing(['email', 'location_id'], $indexDefinition->getIndexColumns());
 
         $this->assertEquals('$table->unique([\'email\', \'location_id\'], \'users_email_location_id_unique\')', $indexDefinition->render());
+    }
+
+    public function test_it_tokenizes_two_column_unique_key_and_doesnt_use_index_name()
+    {
+        config()->set('laravel-migration-generator.definitions.use_defined_unique_key_index_names', false);
+        $indexTokenizer = IndexTokenizer::parse('UNIQUE KEY `users_email_location_id_unique` (`email`,`location_id`)');
+        $indexDefinition = $indexTokenizer->definition();
+
+        $this->assertEquals('unique', $indexDefinition->getIndexType());
+        $this->assertTrue($indexDefinition->isMultiColumnIndex());
+        $this->assertCount(2, $indexDefinition->getIndexColumns());
+        $this->assertEqualsCanonicalizing(['email', 'location_id'], $indexDefinition->getIndexColumns());
+
+        $this->assertEquals('$table->unique([\'email\', \'location_id\'])', $indexDefinition->render());
+        config()->set('laravel-migration-generator.definitions.use_defined_unique_key_index_names', true);
     }
 
     //endregion
@@ -89,6 +130,23 @@ class IndexTokenizerTest extends TestCase
         $this->assertEquals(['user_id'], $indexDefinition->getIndexColumns());
 
         $this->assertEquals('$table->foreign(\'user_id\', \'fk_bank_accounts_user_id\')->references(\'id\')->on(\'users\')', $indexDefinition->render());
+    }
+
+    public function test_it_tokenizes_foreign_key_doesnt_use_index_name()
+    {
+        config()->set('laravel-migration-generator.definitions.use_defined_foreign_key_index_names', false);
+        $indexTokenizer = IndexTokenizer::parse('CONSTRAINT `fk_bank_accounts_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)');
+        $indexDefinition = $indexTokenizer->definition();
+
+        $this->assertEquals('foreign', $indexDefinition->getIndexType());
+        $this->assertFalse($indexDefinition->isMultiColumnIndex());
+        $this->assertCount(1, $indexDefinition->getIndexColumns());
+        $this->assertEquals('users', $indexDefinition->getForeignReferencedTable());
+        $this->assertEquals(['id'], $indexDefinition->getForeignReferencedColumns());
+        $this->assertEquals(['user_id'], $indexDefinition->getIndexColumns());
+
+        $this->assertEquals('$table->foreign(\'user_id\')->references(\'id\')->on(\'users\')', $indexDefinition->render());
+        config()->set('laravel-migration-generator.definitions.use_defined_foreign_key_index_names', true);
     }
 
     public function test_it_tokenizes_foreign_key_with_update()


### PR DESCRIPTION
Previous PR only effected multi-column indices. This PR makes single column index methods use index names too.