### PR TITLE
Environment variables and run after migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+#Version 2.3.0
+
+### Run after migrations
+When `LMG_RUN_AFTER_MIGRATIONS` is set to true, after running any of the `artisan migrate` commands, the `generate:migrations` command will be run using all the default options for the command. It will only run when the app environment is `testing`.
+
+### Environment Variables
+New environment variables to replace config updates:
+
+| Key | Default Value | Allowed Values | Description |
+| --- | ------------- | -------------- | ----------- |
+| LMG_RUN_AFTER_MIGRATIONS | false | boolean | Whether or not the migration generator should run after migrations have completed. |
+| LMG_CLEAR_OUTPUT_PATH | false | boolean | Whether or not to clear out the output path before creating new files |
+| LMG_TABLE_NAMING_SCHEME | [Timestamp]_create_[TableName]_table.php | string | The string to be used to name table migration files |
+| LMG_VIEW_NAMING_SCHEME | [Timestamp]_create_[ViewName]_view.php | string | The string to be used to name view migration files |
+| LMG_OUTPUT_PATH | tests/database/migrations | string | The path (relative to the root of your project) to where the files will be output to |
+| LMG_SKIPPABLE_TABLES | migrations | comma delimited string | The tables to be skipped |
+| LMG_PREFER_UNSIGNED_PREFIX | true | boolean | When true, uses `unsigned` variant methods instead of the `->unsigned()` modifier. |
+| LMG_USE_DEFINED_INDEX_NAMES | true | boolean | When true, uses index names defined by the database as the name parameter for index methods |
+| LMG_USE_DEFINED_FOREIGN_KEY_INDEX_NAMES | true | boolean | When true, uses foreign key index names defined by the database as the name parameter for foreign key methods |
+| LMG_USE_DEFINED_UNIQUE_KEY_INDEX_NAMES | true | boolean | When true, uses unique key index names defined by the database as the name parameter for the `unique` methods |
+| LMG_USE_DEFINED_PRIMARY_KEY_INDEX_NAMES | true | boolean | When true, uses primary key index name defined by the database as the name parameter for the `primary` method |
+| LMG_MYSQL_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `mysql`. |
+| LMG_MYSQL_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `mysql`. |
+| LMG_MYSQL_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `mysql`. |
+| LMG_MYSQL_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `mysql`. |
+| LMG_SQLITE_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `sqlite`. |
+| LMG_SQLITE_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `sqlite`. |
+| LMG_SQLITE_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `sqlite`. |
+| LMG_SQLITE_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `sqlite`. |
+| LMG_PGSQL_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `pgsql`. |
+| LMG_PGSQL_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `pgsql`. |
+| LMG_PGSQL_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `pgsql`. |
+| LMG_PGSQL_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `pgsql`. |
+| LMG_SQLSRV_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `sqlsrc`. |
+| LMG_SQLSRV_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `sqlsrv`. |
+| LMG_SQLSRV_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `sqlsrv`. |
+| LMG_SQLSRV_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `sqlsrv`. |

--- a/README.md
+++ b/README.md
@@ -34,28 +34,48 @@ php artisan generate:migrations --empty-path
 
 # Configuration
 
-Each database driver can have separate configs, as specified in `config/laravel-migration-generator.php`.
-
 Want to customize the migration stubs? Make sure you've published the vendor assets with the artisan command to publish vendor files above.
 
-## Definition Output Preferences
+## Environment Variables
 
-| Key | Values | Description |
-| --- | ------ | ----------- |
-| prefer_unsigned_prefix | boolean | Set to true to use the `unsigned` prefix for the applicable fields (integer, smallInteger, etc). Set to false to use the `unsigned()` modifier. |
-| use_defined_index_names | boolean | Set to true to use the defined index names as second parameter for the `->index()` method. Set to false to default to Laravel's index naming scheme. |
-| use_defined_foreign_key_index_names | boolean | Set to true to use the defined index names for foreign keys as second parameter for the `->foreign()` method. Set to false to default to Laravel's index naming scheme. |
-| use_defined_unique_key_index_names | boolean | Set to true to use the defined index names for unique keys as second parameter for the `->unique()` method. Set to false to default to Laravel's index naming scheme. |
-| use_defined_primary_key_index_names | boolean | Set to true to use the defined index names for primary keys as second parameter for the `->primary()` method. Set to false to default to Laravel's index naming scheme. |
+| Key | Default Value | Allowed Values | Description |
+| --- | ------------- | -------------- | ----------- |
+| LMG_RUN_AFTER_MIGRATIONS | false | boolean | Whether or not the migration generator should run after migrations have completed. |
+| LMG_CLEAR_OUTPUT_PATH | false | boolean | Whether or not to clear out the output path before creating new files. Same as specifying `--empty-path` on the command |
+| LMG_TABLE_NAMING_SCHEME | [Timestamp]_create_[TableName]_table.php | string | The string to be used to name table migration files |
+| LMG_VIEW_NAMING_SCHEME | [Timestamp]_create_[ViewName]_view.php | string | The string to be used to name view migration files |
+| LMG_OUTPUT_PATH | tests/database/migrations | string | The path (relative to the root of your project) to where the files will be output to. Same as specifying `--path=` on the command |
+| LMG_SKIPPABLE_TABLES | migrations | comma delimited string | The tables to be skipped |
+| LMG_PREFER_UNSIGNED_PREFIX | true | boolean | When true, uses `unsigned` variant methods instead of the `->unsigned()` modifier. |
+| LMG_USE_DEFINED_INDEX_NAMES | true | boolean | When true, uses index names defined by the database as the name parameter for index methods |
+| LMG_USE_DEFINED_FOREIGN_KEY_INDEX_NAMES | true | boolean | When true, uses foreign key index names defined by the database as the name parameter for foreign key methods |
+| LMG_USE_DEFINED_UNIQUE_KEY_INDEX_NAMES | true | boolean | When true, uses unique key index names defined by the database as the name parameter for the `unique` methods |
+| LMG_USE_DEFINED_PRIMARY_KEY_INDEX_NAMES | true | boolean | When true, uses primary key index name defined by the database as the name parameter for the `primary` method |
+| LMG_MYSQL_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `mysql`. |
+| LMG_MYSQL_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `mysql`. |
+| LMG_MYSQL_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `mysql`. |
+| LMG_MYSQL_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `mysql`. |
+| LMG_SQLITE_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `sqlite`. |
+| LMG_SQLITE_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `sqlite`. |
+| LMG_SQLITE_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `sqlite`. |
+| LMG_SQLITE_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `sqlite`. |
+| LMG_PGSQL_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `pgsql`. |
+| LMG_PGSQL_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `pgsql`. |
+| LMG_PGSQL_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `pgsql`. |
+| LMG_PGSQL_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `pgsql`. |
+| LMG_SQLSRV_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `sqlsrc`. |
+| LMG_SQLSRV_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `sqlsrv`. |
+| LMG_SQLSRV_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `sqlsrv`. |
+| LMG_SQLSRV_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `sqlsrv`. |
 
 ## Stubs
 There is a default stub for tables and views, found in `resources/stubs/vendor/laravel-migration-generator/`.
 Each database driver can be assigned a specific migration stub by creating a new stub file in `resources/stubs/vendor/laravel-migration-generator/` with a `driver`-prefix, e.g. `mysql-table.stub` for a MySQL specific table stub.
 
 ## Stub Naming
-Stubs can be named using the `(table|view)_naming_scheme` in the config. See below for available tokens that can be replaced.
+Table and view stubs can be named using the `LMG_(TABLE|VIEW)_NAMING_SCHEME` environment variables. Optionally, driver-specific naming schemes can be used as well by specifying `LMG_{driver}_TABLE_NAMING_SCHEME` environment vars using the same tokens. See below for available tokens that can be replaced.
 
-### Table Stubs
+### Table Name Stub Tokens
 Table stubs have the following tokens available for the naming scheme:
 
 | Token | Example | Description |
@@ -66,6 +86,8 @@ Table stubs have the following tokens available for the naming scheme:
 | `[Timestamp]` | 2021_04_25_110000 | The standard migration timestamp format, at the time of calling the command: `Y_m_d_His` |
 | `[Timestamp:{format}]` | {Y_m} = 2021_04 |Specify a format for the timestamp, e.g. \[Timestamp:Y_m\] |
 
+
+### Table Schema Stub Tokens
 Table schema stubs have the following tokens available:
 
 | Token | Description |
@@ -75,7 +97,7 @@ Table schema stubs have the following tokens available:
 | `[Schema]` | The table's generated schema |
 
 
-### View Stubs
+### View Name Stub Tokens
 View stubs have the following tokens available for the naming scheme:
 
 | Token | Example | Description |
@@ -86,6 +108,7 @@ View stubs have the following tokens available for the naming scheme:
 | `[Timestamp]` | 2021_04_25_110000 | The standard migration timestamp format, at the time of calling the command: `Y_m_d_His` |
 | `[Timestamp:{format}]` | {Y_m} = 2021_04 |Specify a format for the timestamp, e.g. \[Timestamp:Y_m\] |
 
+### View Schema Stub Tokens
 View schema stubs have the following tokens available:
 
 | Token | Description |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,36 @@
+## Upgrade from 2.2.* to 3.0.0
+
+`skippable_tables` is now a comma delimited string instead of an array so they are compatible with .env files.
+
+All config options have been moved to equivalent .env variables and the config is no longer publishable. Please delete `config/laravel-migration-generator.php`.
+The new environment variables are below:
+
+| Key | Default Value | Allowed Values | Description |
+| --- | ------------- | -------------- | ----------- |
+| LMG_RUN_AFTER_MIGRATIONS | false | boolean | Whether or not the migration generator should run after migrations have completed. |
+| LMG_CLEAR_OUTPUT_PATH | false | boolean | Whether or not to clear out the output path before creating new files |
+| LMG_TABLE_NAMING_SCHEME | [Timestamp]_create_[TableName]_table.php | string | The string to be used to name table migration files |
+| LMG_VIEW_NAMING_SCHEME | [Timestamp]_create_[ViewName]_view.php | string | The string to be used to name view migration files |
+| LMG_OUTPUT_PATH | tests/database/migrations | string | The path (relative to the root of your project) to where the files will be output to |
+| LMG_SKIPPABLE_TABLES | migrations | comma delimited string | The tables to be skipped |
+| LMG_PREFER_UNSIGNED_PREFIX | true | boolean | When true, uses `unsigned` variant methods instead of the `->unsigned()` modifier. |
+| LMG_USE_DEFINED_INDEX_NAMES | true | boolean | When true, uses index names defined by the database as the name parameter for index methods |
+| LMG_USE_DEFINED_FOREIGN_KEY_INDEX_NAMES | true | boolean | When true, uses foreign key index names defined by the database as the name parameter for foreign key methods |
+| LMG_USE_DEFINED_UNIQUE_KEY_INDEX_NAMES | true | boolean | When true, uses unique key index names defined by the database as the name parameter for the `unique` methods |
+| LMG_USE_DEFINED_PRIMARY_KEY_INDEX_NAMES | true | boolean | When true, uses primary key index name defined by the database as the name parameter for the `primary` method |
+| LMG_MYSQL_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `mysql`. |
+| LMG_MYSQL_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `mysql`. |
+| LMG_MYSQL_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `mysql`. |
+| LMG_MYSQL_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `mysql`. |
+| LMG_SQLITE_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `sqlite`. |
+| LMG_SQLITE_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `sqlite`. |
+| LMG_SQLITE_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `sqlite`. |
+| LMG_SQLITE_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `sqlite`. |
+| LMG_PGSQL_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `pgsql`. |
+| LMG_PGSQL_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `pgsql`. |
+| LMG_PGSQL_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `pgsql`. |
+| LMG_PGSQL_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `pgsql`. |
+| LMG_SQLSRV_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `sqlsrc`. |
+| LMG_SQLSRV_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `sqlsrv`. |
+| LMG_SQLSRV_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `sqlsrv`. |
+| LMG_SQLSRV_SKIPPABLE_TABLES | null | ?boolean | When not null, this setting will override LMG_SKIPPABLE_TABLES when the database driver is `sqlsrv`. |

--- a/config/laravel-migration-generator.php
+++ b/config/laravel-migration-generator.php
@@ -1,45 +1,45 @@
 <?php
 
 return [
+    'run_after_migrations' => env('LMG_RUN_AFTER_MIGRATIONS', false),
+    'clear_output_path'    => env('LMG_CLEAR_OUTPUT_PATH', false),
     //default configs
-    'table_naming_scheme' => '[Timestamp]_create_[TableName]_table.php',
-    'view_naming_scheme'  => '[Timestamp]_create_[ViewName]_view.php',
-    'path'                => base_path('tests/database/migrations'),
-    'skippable_tables'    => [
-        'migrations'
-    ],
-    'definitions' => [
-        'prefer_unsigned_prefix'              => true,
-        'use_defined_index_names'             => true,
-        'use_defined_foreign_key_index_names' => true,
-        'use_defined_unique_key_index_names'  => true,
-        'use_defined_primary_key_index_names' => true
+    'table_naming_scheme' => env('LMG_TABLE_NAMING_SCHEME', '[Timestamp]_create_[TableName]_table.php'),
+    'view_naming_scheme'  => env('LMG_VIEW_NAMING_SCHEME', '[Timestamp]_create_[ViewName]_view.php'),
+    'path'                => env('LMG_OUTPUT_PATH', 'tests/database/migrations'),
+    'skippable_tables'    => env('LMG_SKIPPABLE_TABLES', 'migrations'),
+    'definitions'         => [
+        'prefer_unsigned_prefix'              => env('LMG_PREFER_UNSIGNED_PREFIX', true),
+        'use_defined_index_names'             => env('LMG_USE_DEFINED_INDEX_NAMES', true),
+        'use_defined_foreign_key_index_names' => env('LMG_USE_DEFINED_FOREIGN_KEY_INDEX_NAMES', true),
+        'use_defined_unique_key_index_names'  => env('LMG_USE_DEFINED_UNIQUE_KEY_INDEX_NAMES', true),
+        'use_defined_primary_key_index_names' => env('LMG_USE_DEFINED_PRIMARY_KEY_INDEX_NAMES', true)
     ],
 
     //now driver specific configs
     //null = use default
     'mysql' => [
-        'table_naming_scheme' => null,
-        'view_naming_scheme'  => null,
-        'path'                => null,
-        'skippable_tables'    => null
+        'table_naming_scheme' => env('LMG_MYSQL_TABLE_NAMING_SCHEME', null),
+        'view_naming_scheme'  => env('LMG_MYSQL_VIEW_NAMING_SCHEME', null),
+        'path'                => env('LMG_MYSQL_OUTPUT_PATH', null),
+        'skippable_tables'    => env('LMG_MYSQL_SKIPPABLE_TABLES', null)
     ],
     'sqlite' => [
-        'table_naming_scheme' => null,
-        'view_naming_scheme'  => null,
-        'path'                => null,
-        'skippable_tables'    => null
+        'table_naming_scheme' => env('LMG_SQLITE_TABLE_NAMING_SCHEME', null),
+        'view_naming_scheme'  => env('LMG_SQLITE_VIEW_NAMING_SCHEME', null),
+        'path'                => env('LMG_SQLITE_OUTPUT_PATH', null),
+        'skippable_tables'    => env('LMG_MYSQL_SKIPPABLE_TABLES', null)
     ],
     'pgsql' => [
-        'table_naming_scheme' => null,
-        'view_naming_scheme'  => null,
-        'path'                => null,
-        'skippable_tables'    => null
+        'table_naming_scheme' => env('LMG_PGSQL_TABLE_NAMING_SCHEME', null),
+        'view_naming_scheme'  => env('LMG_PGSQL_VIEW_NAMING_SCHEME', null),
+        'path'                => env('LMG_PGSQL_OUTPUT_PATH', null),
+        'skippable_tables'    => env('LMG_PGSQL_SKIPPABLE_TABLES', null)
     ],
     'sqlsrv' => [
-        'table_naming_scheme' => null,
-        'view_naming_scheme'  => null,
-        'path'                => null,
-        'skippable_tables'    => null
+        'table_naming_scheme' => env('LMG_SQLSRV_TABLE_NAMING_SCHEME', null),
+        'view_naming_scheme'  => env('LMG_SQLSRV_VIEW_NAMING_SCHEME', null),
+        'path'                => env('LMG_SQLSRV_OUTPUT_PATH', null),
+        'skippable_tables'    => env('LMG_SQLSRV_SKIPPABLE_TABLES', null)
     ],
 ];

--- a/src/Commands/GenerateMigrationsCommand.php
+++ b/src/Commands/GenerateMigrationsCommand.php
@@ -63,9 +63,9 @@ class GenerateMigrationsCommand extends Command
             return 1;
         }
 
-        $basePath = $this->getPath($driver);
+        $basePath = base_path($this->getPath($driver));
 
-        if ($this->option('empty-path')) {
+        if ($this->option('empty-path') || config('laravel-migration-generator.clear_output_path')) {
             foreach (glob($basePath . '/*.php') as $file) {
                 unlink($file);
             }

--- a/src/Helpers/ConfigResolver.php
+++ b/src/Helpers/ConfigResolver.php
@@ -27,6 +27,6 @@ class ConfigResolver
 
     public static function skippableTables(string $driver)
     {
-        return static::resolver('skippable_tables', $driver);
+        return array_map('trim', explode(',', static::resolver('skippable_tables', $driver)));
     }
 }

--- a/src/LaravelMigrationGeneratorProvider.php
+++ b/src/LaravelMigrationGeneratorProvider.php
@@ -2,7 +2,10 @@
 
 namespace LaravelMigrationGenerator;
 
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Events\MigrationsEnded;
 use LaravelMigrationGenerator\Commands\GenerateMigrationsCommand;
 
 class LaravelMigrationGeneratorProvider extends ServiceProvider
@@ -15,8 +18,7 @@ class LaravelMigrationGeneratorProvider extends ServiceProvider
         );
 
         $this->publishes([
-            __DIR__ . '/../stubs'                                  => resource_path('stubs/vendor/laravel-migration-generator'),
-            __DIR__ . '/../config/laravel-migration-generator.php' => config_path('laravel-migration-generator.php')
+            __DIR__ . '/../stubs' => resource_path('stubs/vendor/laravel-migration-generator')
         ]);
 
         if ($this->app->runningInConsole()) {
@@ -24,6 +26,11 @@ class LaravelMigrationGeneratorProvider extends ServiceProvider
             $this->commands([
                 GenerateMigrationsCommand::class
             ]);
+        }
+        if (config('laravel-migration-generator.run_after_migrations') && config('app.env') == 'testing') {
+            Event::listen(MigrationsEnded::class, function () {
+                Artisan::call('generate:migrations');
+            });
         }
     }
 }


### PR DESCRIPTION
Start of v3 since it's a pretty big break from the previous releases with env vars