### PR TITLE
Sort migrations so migrations for dependent tables occur prior to the tables that depend on them (WIP) 

### DIFF
--- a/src/Generators/BaseTableGenerator.php
+++ b/src/Generators/BaseTableGenerator.php
@@ -2,6 +2,7 @@
 
 namespace LaravelMigrationGenerator\Generators;
 
+use Illuminate\Support\Collection;
 use LaravelMigrationGenerator\Helpers\WritableTrait;
 use LaravelMigrationGenerator\Generators\Concerns\WritesTablesToFile;
 use LaravelMigrationGenerator\Generators\Concerns\CleansUpMorphColumns;
@@ -51,6 +52,11 @@ abstract class BaseTableGenerator implements TableGeneratorInterface
         return $instance;
     }
 
+    public static function sort(Collection $generators): Collection
+    {
+        return $generators;
+    }
+
     public function shouldResolveStructure(): bool
     {
         return count($this->rows) === 0;
@@ -70,5 +76,10 @@ abstract class BaseTableGenerator implements TableGeneratorInterface
     public function getIndices(): array
     {
         return $this->indices;
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
     }
 }

--- a/src/Generators/BaseViewGenerator.php
+++ b/src/Generators/BaseViewGenerator.php
@@ -2,6 +2,7 @@
 
 namespace LaravelMigrationGenerator\Generators;
 
+use Illuminate\Support\Collection;
 use LaravelMigrationGenerator\Helpers\WritableTrait;
 use LaravelMigrationGenerator\Generators\Concerns\WritesViewsToFile;
 use LaravelMigrationGenerator\Generators\Interfaces\ViewGeneratorInterface;
@@ -30,6 +31,11 @@ abstract class BaseViewGenerator implements ViewGeneratorInterface
         $obj->parse();
 
         return $obj;
+    }
+
+    public static function sort(Collection $generators): Collection
+    {
+        return $generators;
     }
 
     public function getSchema(): ?string

--- a/src/Helpers/Time.php
+++ b/src/Helpers/Time.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LaravelMigrationGenerator\Helpers;
+
+use Carbon\Carbon;
+
+class Time
+{
+    private Carbon $current;
+
+    public function __construct()
+    {
+        $this->current = Carbon::now()->startOfHour();
+    }
+
+    public function format(string $format): string
+    {
+        $result = $this->current->format($format);
+        $this->current = $this->current->addSecond();
+
+        return $result;
+    }
+}

--- a/src/LaravelMigrationGeneratorProvider.php
+++ b/src/LaravelMigrationGeneratorProvider.php
@@ -2,11 +2,13 @@
 
 namespace LaravelMigrationGenerator;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Events\MigrationsEnded;
 use LaravelMigrationGenerator\Commands\GenerateMigrationsCommand;
+use LaravelMigrationGenerator\Helpers\Time;
 
 class LaravelMigrationGeneratorProvider extends ServiceProvider
 {
@@ -23,7 +25,7 @@ class LaravelMigrationGeneratorProvider extends ServiceProvider
         ]);
 
         if ($this->app->runningInConsole()) {
-            $this->app->instance('laravel-migration-generator:time', now());
+            $this->app->instance('laravel-migration-generator:time', new Time());
             $this->commands([
                 GenerateMigrationsCommand::class
             ]);


### PR DESCRIPTION
I was fiddling with your migration generator, adding dependency sorting so migrations can be run with FK enabled in MySql.   This is WIP that got me close enough that I could tweak the remaining errors by hand.  Just wanted to make you aware its floating around in case you want to pick this up and run with it.  I may circle back myself at some point to turn this into a real PR (biggest thing needed is add support for generating table modification migrations containing the FK constraints that need to be deferred and a lot more testing).