### PR TITLE
Expand regex space replacing enum character compatibility

### DIFF
--- a/src/Tokenizers/BaseTokenizer.php
+++ b/src/Tokenizers/BaseTokenizer.php
@@ -19,7 +19,7 @@ abstract class BaseTokenizer
         $this->value = $value;
         $prune = false;
         //\(?\'(.+?)?\s(.+?)?\'\)?
-        if (preg_match_all("/'([A-Za-z ]+)'(?=[^A-Za-z])/", $value, $matches)) {
+        if (preg_match_all("/'([A-Za-z1-9\/ ]+)'(?=[^A-Za-z1-9\/])/", $value, $matches)) {
             foreach ($matches[0] as $quoteWithSpace) {
                 //we've got an enum or set that has spaces in the text
                 //so we'll convert to a different character so it doesn't get pruned


### PR DESCRIPTION
I found an issue with enums that contain numbers or forward slashes.

**Input examples**
`Text 1 example`
`Text a/b`

I have expanded the regex to process those characters. I expect there could be additional characters that possibly should be added.

Previously the regex would be up regexes incorrectly and then cause a fatal error later:
`laravel-migration-generator/src/Tokenizers/MySQL/ColumnTokenizer.php(91): Undefined array key 1`