### PR TITLE
Feature: use defined datatype on timestamp columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Want to customize the migration stubs? Make sure you've published the vendor ass
 | LMG_USE_DEFINED_FOREIGN_KEY_INDEX_NAMES | true | boolean | When true, uses foreign key index names defined by the database as the name parameter for foreign key methods |
 | LMG_USE_DEFINED_UNIQUE_KEY_INDEX_NAMES | true | boolean | When true, uses unique key index names defined by the database as the name parameter for the `unique` methods |
 | LMG_USE_DEFINED_PRIMARY_KEY_INDEX_NAMES | true | boolean | When true, uses primary key index name defined by the database as the name parameter for the `primary` method |
+| LMG_USE_DEFINED_DATATYPE_ON_TIMESTAMP | false | boolean | When false, uses `->timestamps()` by mashing up `created_at` and `updated_at` regardless of  datatype defined by the database |
 | LMG_MYSQL_TABLE_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_TABLE_NAMING_SCHEME when the database driver is `mysql`. |
 | LMG_MYSQL_VIEW_NAMING_SCHEME | null | ?boolean | When not null, this setting will override LMG_VIEW_NAMING_SCHEME when the database driver is `mysql`. |
 | LMG_MYSQL_OUTPUT_PATH | null | ?boolean | When not null, this setting will override LMG_OUTPUT_PATH when the database driver is `mysql`. |

--- a/config/laravel-migration-generator.php
+++ b/config/laravel-migration-generator.php
@@ -15,7 +15,8 @@ return [
         'use_defined_index_names'             => env('LMG_USE_DEFINED_INDEX_NAMES', true),
         'use_defined_foreign_key_index_names' => env('LMG_USE_DEFINED_FOREIGN_KEY_INDEX_NAMES', true),
         'use_defined_unique_key_index_names'  => env('LMG_USE_DEFINED_UNIQUE_KEY_INDEX_NAMES', true),
-        'use_defined_primary_key_index_names' => env('LMG_USE_DEFINED_PRIMARY_KEY_INDEX_NAMES', true)
+        'use_defined_primary_key_index_names' => env('LMG_USE_DEFINED_PRIMARY_KEY_INDEX_NAMES', true),
+        'use_defined_datatype_on_timestamp'   => env('LMG_USE_DEFINED_DATATYPE_ON_TIMESTAMP', false),
     ],
 
     //now driver specific configs

--- a/src/Definitions/IndexDefinition.php
+++ b/src/Definitions/IndexDefinition.php
@@ -179,12 +179,14 @@ class IndexDefinition
             if (config('laravel-migration-generator.definitions.use_defined_unique_key_index_names')) {
                 $indexName = ', \'' . $this->getIndexName() . '\'';
             }
+
             return '$table->unique(' . ValueToString::make($this->indexColumns) . $indexName . ')';
         } elseif ($this->indexType === 'index') {
             $indexName = '';
             if (config('laravel-migration-generator.definitions.use_defined_index_names')) {
                 $indexName = ', \'' . $this->getIndexName() . '\'';
             }
+
             return '$table->index(' . ValueToString::make($this->indexColumns) . $indexName . ')';
         }
 

--- a/src/Generators/BaseTableGenerator.php
+++ b/src/Generators/BaseTableGenerator.php
@@ -62,7 +62,7 @@ abstract class BaseTableGenerator implements TableGeneratorInterface
 
         $this->cleanUpMorphColumns();
 
-        if (!config('laravel-migration-generator.definitions.use_defined_datatype_on_timestamp')) {
+        if (! config('laravel-migration-generator.definitions.use_defined_datatype_on_timestamp')) {
             $this->cleanUpTimestampsColumn();
         }
 

--- a/src/Generators/BaseTableGenerator.php
+++ b/src/Generators/BaseTableGenerator.php
@@ -62,7 +62,9 @@ abstract class BaseTableGenerator implements TableGeneratorInterface
 
         $this->cleanUpMorphColumns();
 
-        $this->cleanUpTimestampsColumn();
+        if (!config('laravel-migration-generator.definitions.use_defined_datatype_on_timestamp')) {
+            $this->cleanUpTimestampsColumn();
+        }
 
         $this->cleanUpColumnsWithIndices();
     }

--- a/src/Tokenizers/MySQL/ColumnTokenizer.php
+++ b/src/Tokenizers/MySQL/ColumnTokenizer.php
@@ -40,7 +40,7 @@ class ColumnTokenizer extends BaseColumnTokenizer
 
         $this->consumeGenerated();
 
-        if ($this->columnDataType == 'timestamp') {
+        if ($this->columnDataType == 'timestamp' || $this->columnDataType == 'datetime') {
             $this->consumeTimestamp();
         }
 

--- a/src/Tokenizers/MySQL/ColumnTokenizer.php
+++ b/src/Tokenizers/MySQL/ColumnTokenizer.php
@@ -44,10 +44,6 @@ class ColumnTokenizer extends BaseColumnTokenizer
             $this->consumeTimestamp();
         }
 
-        if ($this->columnDataType == 'timestamp') {
-            $this->consumeTimestamp();
-        }
-
         return $this;
     }
 

--- a/tests/Unit/Generators/MySQLTableGeneratorTest.php
+++ b/tests/Unit/Generators/MySQLTableGeneratorTest.php
@@ -179,6 +179,19 @@ class MySQLTableGeneratorTest extends TestCase
         $this->assertSchemaHas('$table->timestamp(\'updated_at\')->nullable()->useCurrentOnUpdate()', $schema);
     }
 
+    public function test_doesnt_clean_timestamps_with_use_defined_datatype_on_timestamp_configuration()
+    {
+        config()->set('laravel-migration-generator.definitions.use_defined_datatype_on_timestamp', true);
+        $generator = TableGenerator::init('table', [
+            'id int auto_increment primary key',
+            'created_at datetime NOT NULL',
+            'updated_at datetime NOT NULL'
+        ]);
+        $schema = $generator->getSchema();
+        $this->assertSchemaHas('$table->dateTime(\'created_at\')', $schema);
+        $this->assertSchemaHas('$table->dateTime(\'updated_at\')', $schema);
+    }
+
     public function test_removes_index_from_column_if_fk()
     {
         $generator = TableGenerator::init('test', [

--- a/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
+++ b/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
@@ -612,6 +612,21 @@ class ColumnTokenizerTest extends TestCase
         $this->assertEquals('$table->dateTime(\'sent_at\')->nullable()->useCurrent()', $columnDefinition->render());
     }
 
+    public function test_it_tokenizes_a_null_default_value_now_and_on_update_datetime_column()
+    {
+        $columnTokenizer = ColumnTokenizer::parse('`sent_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP');
+        $columnDefinition = $columnTokenizer->definition();
+
+        $this->assertEquals('sent_at', $columnDefinition->getColumnName());
+        $this->assertEquals('datetime', $columnTokenizer->getColumnDataType());
+        $this->assertEquals('dateTime', $columnDefinition->getMethodName());
+        $this->assertCount(0, $columnDefinition->getMethodParameters());
+        $this->assertNull($columnDefinition->getDefaultValue());
+        $this->assertTrue($columnDefinition->isNullable());
+        $this->assertFalse($columnDefinition->isUnsigned());
+        $this->assertNull($columnDefinition->getCollation());
+        $this->assertEquals('$table->dateTime(\'sent_at\')->nullable()->useCurrent()->useCurrentOnUpdate()', $columnDefinition->render());
+    }
     //endregion
 
     //region TIMESTAMP


### PR DESCRIPTION
Thank you for creating awesome tool!
On timestamp columns `created_at` and `updated_at`, I prefer datetime type (not timestamp).
Added new configuration `LMG_USE_DEFINED_DATATYPE_ON_TIMESTAMP` for that.
Note that I didn't change the behavior by default. (You need configuration to use datetime datatype.)