### PR TITLE
Fixing a bug where CHARACTER SET breaks everything

### DIFF
--- a/src/Definitions/ColumnDefinition.php
+++ b/src/Definitions/ColumnDefinition.php
@@ -4,7 +4,6 @@ namespace LaravelMigrationGenerator\Definitions;
 
 use Illuminate\Support\Str;
 use LaravelMigrationGenerator\Helpers\ValueToString;
-use LaravelMigrationGenerator\Helpers\WritableTrait;
 
 /**
  * Class ColumnDefinition
@@ -25,6 +24,8 @@ class ColumnDefinition
     protected bool $nullable = true;
 
     protected $defaultValue;
+
+    protected ?string $characterSet = null;
 
     protected ?string $collation = null;
 
@@ -110,6 +111,14 @@ class ColumnDefinition
         }
 
         return $this->defaultValue;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCharacterSet(): ?string
+    {
+        return $this->characterSet;
     }
 
     /**
@@ -252,6 +261,17 @@ class ColumnDefinition
     public function setDefaultValue($defaultValue)
     {
         $this->defaultValue = $defaultValue;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $collation
+     * @return ColumnDefinition
+     */
+    public function setCharacterSet(?string $characterSet): ColumnDefinition
+    {
+        $this->characterSet = $characterSet;
 
         return $this;
     }

--- a/src/Definitions/ColumnDefinition.php
+++ b/src/Definitions/ColumnDefinition.php
@@ -4,6 +4,7 @@ namespace LaravelMigrationGenerator\Definitions;
 
 use Illuminate\Support\Str;
 use LaravelMigrationGenerator\Helpers\ValueToString;
+use LaravelMigrationGenerator\Helpers\WritableTrait;
 
 /**
  * Class ColumnDefinition

--- a/src/Tokenizers/MySQL/ColumnTokenizer.php
+++ b/src/Tokenizers/MySQL/ColumnTokenizer.php
@@ -140,6 +140,7 @@ class ColumnTokenizer extends BaseColumnTokenizer
                     }
                 } else {
                     $this->definition->setDefaultValue((string) $this->definition->getDefaultValue());
+                    $this->definition->setNullable(false);
                 }
             }
         } else {

--- a/src/Tokenizers/MySQL/ColumnTokenizer.php
+++ b/src/Tokenizers/MySQL/ColumnTokenizer.php
@@ -26,6 +26,9 @@ class ColumnTokenizer extends BaseColumnTokenizer
             $this->consumeZeroFill();
         }
         if ($this->isTextType()) {
+            //possibly has a character set
+            $this->consumeCharacterSet();
+
             //has collation data most likely
             $this->consumeCollation();
         }
@@ -40,7 +43,11 @@ class ColumnTokenizer extends BaseColumnTokenizer
 
         $this->consumeGenerated();
 
-        if ($this->columnDataType == 'timestamp' || $this->columnDataType == 'datetime') {
+        if ($this->columnDataType == 'timestamp') {
+            $this->consumeTimestamp();
+        }
+
+        if ($this->columnDataType == 'timestamp') {
             $this->consumeTimestamp();
         }
 
@@ -136,6 +143,20 @@ class ColumnTokenizer extends BaseColumnTokenizer
                 }
             }
         } else {
+            $this->putBack($piece);
+        }
+    }
+
+    protected function consumeCharacterSet()
+    {
+        $piece = $this->consume();
+
+        if (strtoupper($piece) === 'CHARACTER') {
+            $this->consume(); // SET, throw it away
+
+            $this->definition->setCharacterSet($this->consume());
+        } else {
+            //something else
             $this->putBack($piece);
         }
     }

--- a/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
+++ b/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
@@ -66,6 +66,21 @@ class ColumnTokenizerTest extends TestCase
         $this->assertEquals('$table->string(\'favorite_color\')->nullable()', $columnDefinition->render());
     }
 
+    public function test_it_tokenizes_char_column_with_character_and_collation()
+    {
+        $columnTokenizer = ColumnTokenizer::parse('`country` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT "US"');
+        $columnDefinition = $columnTokenizer->definition();
+
+        $this->assertEquals('country', $columnDefinition->getColumnName());
+        $this->assertEquals('char', $columnTokenizer->getColumnDataType());
+        $this->assertEquals('string', $columnDefinition->getMethodName());
+        $this->assertCount(1, $columnDefinition->getMethodParameters());
+        $this->assertFalse($columnDefinition->isNullable());
+        $this->assertEquals('utf8mb4_unicode_ci', $columnDefinition->getCollation());
+        $this->assertEquals('utf8mb4', $columnDefinition->getCharacterSet());
+        $this->assertEquals('$table->char(\'country\', 2)->default(\'US\')', $columnDefinition->render());
+    }
+
     //endregion
 
     //region TEXT & Variants

--- a/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
+++ b/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
@@ -68,12 +68,12 @@ class ColumnTokenizerTest extends TestCase
 
     public function test_it_tokenizes_char_column_with_character_and_collation()
     {
-        $columnTokenizer = ColumnTokenizer::parse('`country` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT "US"');
+        $columnTokenizer = ColumnTokenizer::parse('`country` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT \'US\'');
         $columnDefinition = $columnTokenizer->definition();
 
         $this->assertEquals('country', $columnDefinition->getColumnName());
         $this->assertEquals('char', $columnTokenizer->getColumnDataType());
-        $this->assertEquals('string', $columnDefinition->getMethodName());
+        $this->assertEquals('char', $columnDefinition->getMethodName());
         $this->assertCount(1, $columnDefinition->getMethodParameters());
         $this->assertFalse($columnDefinition->isNullable());
         $this->assertEquals('utf8mb4_unicode_ci', $columnDefinition->getCollation());


### PR DESCRIPTION
If the tokenized column has a `CHARACTER SET` then `DEFAULT 'US'` gets skipped and not added to the migration.