### PR TITLE
Use Database Prefix

### DIFF
--- a/src/GeneratorManagers/MySQLGeneratorManager.php
+++ b/src/GeneratorManagers/MySQLGeneratorManager.php
@@ -3,6 +3,8 @@
 namespace LaravelMigrationGenerator\GeneratorManagers;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LaravelMigrationGenerator\Definitions\TableDefinition;
 use LaravelMigrationGenerator\Generators\MySQL\ViewGenerator;
 use LaravelMigrationGenerator\Generators\MySQL\TableGenerator;
 use LaravelMigrationGenerator\GeneratorManagers\Interfaces\GeneratorManagerInterface;
@@ -28,5 +30,14 @@ class MySQLGeneratorManager extends BaseGeneratorManager implements GeneratorMan
                 $this->addViewDefinition(ViewGenerator::init($table)->definition());
             }
         }
+    }
+
+    public function addTableDefinition(TableDefinition $tableDefinition): BaseGeneratorManager
+    {
+        $prefix = config('database.connections.'.DB::getDefaultConnection().'.prefix', '');
+        if(!empty($prefix) && Str::startsWith($tableDefinition->getTableName(), $prefix)){
+            $tableDefinition->setTableName(Str::replaceFirst($prefix, '', $tableDefinition->getTableName()));
+        }
+        return parent::addTableDefinition($tableDefinition);
     }
 }

--- a/src/GeneratorManagers/MySQLGeneratorManager.php
+++ b/src/GeneratorManagers/MySQLGeneratorManager.php
@@ -2,8 +2,8 @@
 
 namespace LaravelMigrationGenerator\GeneratorManagers;
 
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
 use LaravelMigrationGenerator\Definitions\TableDefinition;
 use LaravelMigrationGenerator\Generators\MySQL\ViewGenerator;
 use LaravelMigrationGenerator\Generators\MySQL\TableGenerator;
@@ -34,10 +34,11 @@ class MySQLGeneratorManager extends BaseGeneratorManager implements GeneratorMan
 
     public function addTableDefinition(TableDefinition $tableDefinition): BaseGeneratorManager
     {
-        $prefix = config('database.connections.'.DB::getDefaultConnection().'.prefix', '');
-        if(!empty($prefix) && Str::startsWith($tableDefinition->getTableName(), $prefix)){
+        $prefix = config('database.connections.' . DB::getDefaultConnection() . '.prefix', '');
+        if (! empty($prefix) && Str::startsWith($tableDefinition->getTableName(), $prefix)) {
             $tableDefinition->setTableName(Str::replaceFirst($prefix, '', $tableDefinition->getTableName()));
         }
+
         return parent::addTableDefinition($tableDefinition);
     }
 }

--- a/tests/Unit/GeneratorManagers/MySQLGeneratorManagerTest.php
+++ b/tests/Unit/GeneratorManagers/MySQLGeneratorManagerTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Unit\GeneratorManagers;
 
-use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 use Mockery\MockInterface;
+use Illuminate\Support\Facades\DB;
 use LaravelMigrationGenerator\Definitions\IndexDefinition;
 use LaravelMigrationGenerator\Definitions\TableDefinition;
 use LaravelMigrationGenerator\Definitions\ColumnDefinition;
@@ -54,9 +54,10 @@ class MySQLGeneratorManagerTest extends TestCase
         $this->assertStringContainsString('$table->dropForeign', $sorted[3]->formatter()->stubTableDown());
     }
 
-    public function test_can_remove_database_prefix(){
+    public function test_can_remove_database_prefix()
+    {
         $connection = DB::getDefaultConnection();
-        config()->set('database.connections.'.$connection.'.prefix', 'wp_');
+        config()->set('database.connections.' . $connection . '.prefix', 'wp_');
 
         $mocked = $this->partialMock(MySQLGeneratorManager::class, function (MockInterface $mock) {
             $mock->shouldReceive('init');

--- a/tests/Unit/GeneratorManagers/MySQLGeneratorManagerTest.php
+++ b/tests/Unit/GeneratorManagers/MySQLGeneratorManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\GeneratorManagers;
 
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use LaravelMigrationGenerator\Definitions\IndexDefinition;
@@ -51,5 +52,23 @@ class MySQLGeneratorManagerTest extends TestCase
         $sorted = $mocked->sortTables($mocked->getTableDefinitions());
         $this->assertCount(4, $sorted);
         $this->assertStringContainsString('$table->dropForeign', $sorted[3]->formatter()->stubTableDown());
+    }
+
+    public function test_can_remove_database_prefix(){
+        $connection = DB::getDefaultConnection();
+        config()->set('database.connections.'.$connection.'.prefix', 'wp_');
+
+        $mocked = $this->partialMock(MySQLGeneratorManager::class, function (MockInterface $mock) {
+            $mock->shouldReceive('init');
+        });
+
+        $definition = (new TableDefinition())->setTableName('wp_posts');
+
+        $mocked->addTableDefinition($definition);
+        $this->assertEquals('posts', $definition->getTableName());
+
+        $definition = (new TableDefinition())->setTableName('posts');
+        $mocked->addTableDefinition($definition);
+        $this->assertEquals('posts', $definition->getTableName());
     }
 }

--- a/tests/Unit/GeneratorManagers/MySQLGeneratorManagerTest.php
+++ b/tests/Unit/GeneratorManagers/MySQLGeneratorManagerTest.php
@@ -64,9 +64,19 @@ class MySQLGeneratorManagerTest extends TestCase
         });
 
         $definition = (new TableDefinition())->setTableName('wp_posts');
-
         $mocked->addTableDefinition($definition);
         $this->assertEquals('posts', $definition->getTableName());
+
+        $definition = (new TableDefinition())->setTableName('posts');
+        $mocked->addTableDefinition($definition);
+        $this->assertEquals('posts', $definition->getTableName());
+
+
+        config()->set('database.connections.' . $connection . '.prefix', '');
+
+        $definition = (new TableDefinition())->setTableName('wp_posts');
+        $mocked->addTableDefinition($definition);
+        $this->assertEquals('wp_posts', $definition->getTableName());
 
         $definition = (new TableDefinition())->setTableName('posts');
         $mocked->addTableDefinition($definition);


### PR DESCRIPTION
This PR adds a way for the migration generator to remove any specified `prefix` value in the database config.

Fixes #49 