### PR TITLE
Fix generating enum fields having values of uppercase letters

### DIFF
--- a/src/Tokenizers/MySQL/ColumnTokenizer.php
+++ b/src/Tokenizers/MySQL/ColumnTokenizer.php
@@ -72,7 +72,7 @@ class ColumnTokenizer extends BaseColumnTokenizer
 
     protected function consumeColumnType()
     {
-        $originalColumnType = $columnType = strtolower($this->consume());
+        $originalColumnType = $columnType = $this->consume();
         $hasConstraints = Str::contains($columnType, '(');
 
         if ($hasConstraints) {

--- a/src/Tokenizers/MySQL/ColumnTokenizer.php
+++ b/src/Tokenizers/MySQL/ColumnTokenizer.php
@@ -79,7 +79,7 @@ class ColumnTokenizer extends BaseColumnTokenizer
             $columnType = explode('(', $columnType)[0];
         }
 
-        $this->columnDataType = $columnType;
+        $this->columnDataType = strtolower($columnType);
 
         $this->resolveColumnMethod();
         if ($hasConstraints) {

--- a/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
+++ b/tests/Unit/Tokenizers/MySQL/ColumnTokenizerTest.php
@@ -836,6 +836,21 @@ class ColumnTokenizerTest extends TestCase
         $this->assertEquals('$table->enum(\'status_flag\', [\'1\', \'2\', \'3\', \'4\'])', $columnDefinition->render());
     }
 
+    public function test_it_tokenizes_enum_column_with_upper_case_values()
+    {
+        $columnTokenizer = ColumnTokenizer::parse('`film_rating` enum(\'G\',\'PG\',\'PG-13\',\'R\',\'NC-17\')');
+        $columnDefinition = $columnTokenizer->definition();
+
+        $this->assertEquals('film_rating', $columnDefinition->getColumnName());
+        $this->assertEquals('enum', $columnTokenizer->getColumnDataType());
+        $this->assertEquals('enum', $columnDefinition->getMethodName());
+        $this->assertCount(5, $columnDefinition->getMethodParameters()[0]);
+        $this->assertEqualsCanonicalizing(['G', 'PG', 'PG-13', 'R', 'NC-17'], $columnDefinition->getMethodParameters()[0]);
+        $this->assertNull($columnDefinition->isNullable());
+        $this->assertNull($columnDefinition->getCollation());
+        $this->assertEquals('$table->enum(\'film_rating\', [\'G\', \'PG\', \'PG-13\', \'R\', \'NC-17\'])', $columnDefinition->render());
+    }
+
     public function test_it_tokenizes_not_null_enum_column()
     {
         $columnTokenizer = ColumnTokenizer::parse('`status_flag` enum(\'1\',\'2\',\'3\',\'4\') NOT NULL');


### PR DESCRIPTION
Recently I have started a new side project, utilizing [the existing sakila database][1].

The `film.rating` field is of `enum` type with the following possible values: `G`, `PG`, `PG-13`, `R`, `NC-17`.

When I generate the migrations for the database, this is the statement for the `film.rating` field:

```php
$table->enum('rating', ['g', 'pg', 'pg-13', 'r', 'nc-17'])->default('G');
```

So all possible values are converted to lower case.

The fix is simple, all test cases pass. But I think this could be a breaking change.

Pls let me know if I need to do anything else.

[1]: https://dev.mysql.com/doc/sakila/en/